### PR TITLE
Use single curly brace according to fzf --preview documentation

### DIFF
--- a/internal/command/diff.go
+++ b/internal/command/diff.go
@@ -51,7 +51,7 @@ func newDiffCli(gitOptions []string, fzfQuery string) (*diffCli, error) {
 		gitObjectRange = gitOptions[0]
 	}
 	previewCommand, err := commandFromTemplate("preview", diffFzfPreviewCommand, map[string]interface{}{
-		"path":        "{{2}}",
+		"path":        "{2}",
 		"objectRange": gitObjectRange,
 	})
 	if err != nil {

--- a/internal/command/diff_test.go
+++ b/internal/command/diff_test.go
@@ -34,7 +34,7 @@ func TestNewDiffCommand(t *testing.T) {
 			fzfQuery:   "",
 			want: &diffCli{
 				listOptions: []string{},
-				fzfOption:   fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s", "git diff --color  {{2}}", defaultFzfBindOption),
+				fzfOption:   fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s", "git diff --color  {2}", defaultFzfBindOption),
 			},
 			wantErr: nil,
 		},
@@ -52,7 +52,7 @@ func TestNewDiffCommand(t *testing.T) {
 					"--diff-filter",
 					"A",
 				},
-				fzfOption: fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s --query config", "git diff --color origin/master {{2}}", defaultFzfBindOption),
+				fzfOption: fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s --query config", "git diff --color origin/master {2}", defaultFzfBindOption),
 			},
 			wantErr: nil,
 		},

--- a/internal/command/fzf_test.go
+++ b/internal/command/fzf_test.go
@@ -27,17 +27,17 @@ func TestGetFzfOption(t *testing.T) {
 	}{
 		{
 			name:           "no env vars",
-			previewCommand: "git diff {{1}}",
-			want:           fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s", "git diff {{1}}", defaultFzfBindOption),
+			previewCommand: "git diff {1}",
+			want:           fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s", "git diff {1}", defaultFzfBindOption),
 		},
 		{
 			name:           "all correct env vars",
-			previewCommand: "git diff {{1}}",
+			previewCommand: "git diff {1}",
 			envVars: map[string]string{
 				envNameFzfOption:     fmt.Sprintf("--preview '$GIT_FZF_FZF_PREVIEW_OPTION' --bind $%s", envNameFzfBindOption),
 				envNameFzfBindOption: "ctrl-k:kill-line",
 			},
-			want: fmt.Sprintf("--preview '%s' --bind %s", "git diff {{1}}", "ctrl-k:kill-line"),
+			want: fmt.Sprintf("--preview '%s' --bind %s", "git diff {1}", "ctrl-k:kill-line"),
 		},
 		{
 			name:           "no env vars",

--- a/internal/command/log.go
+++ b/internal/command/log.go
@@ -51,7 +51,7 @@ func newLogCli(gitOptions []string, fzfQuery string) (*logCli, error) {
 		gitObjectRange = gitOptions[0]
 	}
 	previewCommand, err := commandFromTemplate("preview", logFzfPreviewCommand, map[string]interface{}{
-		"path":        "{{1}}",
+		"path":        "{1}",
 		"objectRange": gitObjectRange,
 	})
 	if err != nil {

--- a/internal/command/log_test.go
+++ b/internal/command/log_test.go
@@ -34,7 +34,7 @@ func TestNewLogCommand(t *testing.T) {
 			fzfQuery:   "",
 			want: &logCli{
 				listOptions: []string{},
-				fzfOption:   fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s", "git show --color  {{1}}", defaultFzfBindOption),
+				fzfOption:   fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s", "git show --color  {1}", defaultFzfBindOption),
 			},
 			wantErr: nil,
 		},
@@ -52,7 +52,7 @@ func TestNewLogCommand(t *testing.T) {
 					"--diff-filter",
 					"A",
 				},
-				fzfOption: fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s --query config", "git show --color origin/master {{1}}", defaultFzfBindOption),
+				fzfOption: fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s --query config", "git show --color origin/master {1}", defaultFzfBindOption),
 			},
 			wantErr: nil,
 		},

--- a/internal/command/stash.go
+++ b/internal/command/stash.go
@@ -46,7 +46,7 @@ func NewStashSubcommand() *cobra.Command {
 
 func newStashCli(gitOptions []string, fzfQuery string) (*stashCli, error) {
 	previewCommand, err := commandFromTemplate("preview", stashFzfPreviewCommand, map[string]interface{}{
-		"stash": "{{1}}",
+		"stash": "{1}",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("invalid fzf preview command: %w", err)

--- a/internal/command/stash_test.go
+++ b/internal/command/stash_test.go
@@ -34,7 +34,7 @@ func TestNewStashCommand(t *testing.T) {
 			fzfQuery:   "",
 			want: &stashCli{
 				listOptions: []string{},
-				fzfOption:   fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s", "git stash show --color -p '{{1}}'", defaultFzfBindOption),
+				fzfOption:   fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s", "git stash show --color -p '{1}'", defaultFzfBindOption),
 			},
 			wantErr: nil,
 		},
@@ -50,7 +50,7 @@ func TestNewStashCommand(t *testing.T) {
 					"--diff-filter",
 					"A",
 				},
-				fzfOption: fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s --query config", "git stash show --color -p '{{1}}'", defaultFzfBindOption),
+				fzfOption: fmt.Sprintf("--multi --ansi --inline-info --layout reverse --preview '%s' --preview-window down:70%% --bind %s --query config", "git stash show --color -p '{1}'", defaultFzfBindOption),
 			},
 			wantErr: nil,
 		},


### PR DESCRIPTION
## Summary

The fzf documentation says that to use the output of each line inside
the preview command, the placeholders should be of the form `{[0-9]+}`.

> Also, \fB{q}\fR is replaced to the current query string, and \fB{n}\fR
> is replaced to zero-based ordinal index of the line. Use \fB{+n}\fR if
> you want all index numbers when multiple lines are selected.
> -- https://github.com/junegunn/fzf/blob/master/man/man1/fzf.1#L363-L365

https://github.com/junegunn/fzf

The preview commands generated by git-fzf right now use `{{[0-9]+}}`
(note that this wraps the actual preview number with the extra pair of curly braces).

I am not able to use `{{1}}` to preview with fzf 0.17.5 or fzf
0.18. I can't find any documentation about whether this was a
breaking change inside fzf. I can't find any reference to `{{.}}`
anywhere in the [changelog][1].

The readme doesn't mention which underlying fuzzy finder is being used here. I wonder if it is not junegunn/fzf? 😅 

### Proposed change

I replaced `{{[0-9]}}` with `{[0-9}` across all files.

```sh
$ find . -iname "*.go" | xargs sed -ie 's/{{\([0-9]\)}}/{\1}/g'
```

[1]: https://github.com/junegunn/fzf/blob/master/CHANGELOG.md