### PR TITLE
Run github workflow even if the PR is created from forked repository

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,5 @@
 name: Go
-on: [push]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories
> When you create a pull request from a forked repository to the base repository, GitHub sends the pull_request event to the base repository and no pull request events occur on the forked repository.